### PR TITLE
[WIP] Add routeType attribute & logic to attempt static routes before parameterized routes

### DIFF
--- a/lmdrouter.go
+++ b/lmdrouter.go
@@ -83,6 +83,7 @@ type route struct {
 	re         *regexp.Regexp
 	paramNames []string
 	methods    map[string]resource
+	routeType  string
 }
 
 type resource struct {
@@ -179,6 +180,7 @@ func (l *Router) Route(method, path string, handler Handler, middleware ...Middl
 	if !ok {
 		r = route{
 			methods: make(map[string]resource),
+			routeType: "static", // assume static until we encounter regex
 		}
 
 		// create a regular expression from the path
@@ -193,6 +195,7 @@ func (l *Router) Route(method, path string, handler Handler, middleware ...Middl
 			if strings.HasPrefix(part, ":") {
 				r.paramNames = append(r.paramNames, strings.TrimPrefix(part, ":"))
 				re = fmt.Sprintf("%s/([^/]+)", re)
+				r.routeType = "dynamic"
 			} else {
 				re = fmt.Sprintf("%s/%s", re, part)
 			}
@@ -245,9 +248,14 @@ func (l *Router) Handler(
 	ctx context.Context,
 	req events.APIGatewayProxyRequest,
 ) (events.APIGatewayProxyResponse, error) {
-	rsrc, err := l.matchRequest(&req)
+	// match static routes first
+	rsrc, err := l.matchRequest(&req, "static")
 	if err != nil {
-		return HandleError(err)
+		// match dynamic routes if no resource
+		rsrc, err = l.matchRequest(&req, "dynamic")
+		if err != nil {
+			return HandleError(err)
+		}
 	}
 
 	handler := rsrc.handler
@@ -262,7 +270,7 @@ func (l *Router) Handler(
 	return handler(ctx, req)
 }
 
-func (l *Router) matchRequest(req *events.APIGatewayProxyRequest) (
+func (l *Router) matchRequest(req *events.APIGatewayProxyRequest, routeType string) (
 	rsrc resource,
 	err error,
 ) {
@@ -276,6 +284,10 @@ func (l *Router) matchRequest(req *events.APIGatewayProxyRequest) (
 
 	// find a route that matches the request
 	for _, r := range l.routes {
+		if r.routeType != routeType {
+			continue
+		}
+
 		// does the path match?
 		matches := r.re.FindStringSubmatch(req.Path)
 		if matches == nil {


### PR DESCRIPTION
Issue can be found [here](https://github.com/aquasecurity/lmdrouter/issues/5).

A WIP POC to attempt static routes before those containing a parameter. This would allow overlapping routes to function as intended.
Example:

 - `GET /users/:userid`
 - `GET /users/history`
