### PR TITLE
Add support for passing a time pointer

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -175,7 +176,18 @@ func unmarshalField(
 	case reflect.Bool:
 		valueField.SetBool(boolRegex.MatchString(strings.ToLower(params[param])))
 	case reflect.Ptr:
-		if typeField.Elem().Kind() == reflect.Bool {
+		switch typeField.Elem().Kind() {
+		case reflect.Struct:
+			if val, ok := params[param]; ok {
+				if typeField.Elem() == reflect.TypeOf(time.Now()) {
+					parsedTime, err := time.Parse(time.RFC3339, val)
+					if err != nil {
+						return err
+					}
+					valueField.Set(reflect.ValueOf(&parsedTime))
+				}
+			}
+		case reflect.Bool:
 			if val, ok := params[param]; ok {
 				b := boolRegex.MatchString(strings.ToLower(val))
 				valueField.Set(reflect.ValueOf(&b))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -24,6 +24,7 @@ func Test_UnmarshalRequest(t *testing.T) {
 					"const":     "two",
 					"bool":      "true",
 					"pbool1":    "0",
+					"time":      "2021-11-01T11:11:11.000Z",
 				},
 				MultiValueQueryStringParameters: map[string][]string{
 					"terms":   []string{"one", "two"},
@@ -48,6 +49,8 @@ func Test_UnmarshalRequest(t *testing.T) {
 		assert.True(t, input.Bool, "Bool must be true")
 		assert.NotNil(t, input.PBoolOne, "PBoolOne must not be nil")
 		assert.False(t, *input.PBoolOne, "PBoolOne must be *false")
+		assert.NotNil(t, *input.Time, "Time must not be nil")
+		assert.Equal(t, input.Time.Format(time.RFC3339), "2021-11-01T11:11:11Z")
 		assert.Equal(t, (*bool)(nil), input.PBoolTwo, "PBoolTwo must be nil")
 		assert.DeepEqual(t, []string{"one", "two"}, input.Terms, "Terms must be parsed from multiple query params")
 		assert.DeepEqual(t, []float64{1.2, 3.5, 666.666}, input.Numbers, "Numbers must be parsed from multiple query params")

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/aws/aws-lambda-go v1.15.0 h1:QAhRWvXttl8TtBsODN+NzZETkci2mdN/paJ0+1hX/so=
 github.com/aws/aws-lambda-go v1.15.0/go.mod h1:FEwgPLE6+8wcGBTe5cJN3JWurd1Ztm9zN4jsXsjzKKw=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/structs_test.go
+++ b/structs_test.go
@@ -10,17 +10,18 @@ const (
 )
 
 type mockListRequest struct {
-	ID       string    `lambda:"path.id"`
-	Page     int64     `lambda:"query.page"`
-	PageSize int64     `lambda:"query.page_size"`
-	Terms    []string  `lambda:"query.terms"`
-	Numbers  []float64 `lambda:"query.numbers"`
-	Const    mockConst `lambda:"query.const"`
-	Bool     bool      `lambda:"query.bool"`
-	PBoolOne *bool     `lambda:"query.pbool1"`
-	PBoolTwo *bool     `lambda:"query.pbool2"`
-	Language string    `lambda:"header.Accept-Language"`
-	Encoding []string  `lambda:"header.Accept-Encoding"`
+	ID       string     `lambda:"path.id"`
+	Page     int64      `lambda:"query.page"`
+	PageSize int64      `lambda:"query.page_size"`
+	Terms    []string   `lambda:"query.terms"`
+	Numbers  []float64  `lambda:"query.numbers"`
+	Const    mockConst  `lambda:"query.const"`
+	Bool     bool       `lambda:"query.bool"`
+	PBoolOne *bool      `lambda:"query.pbool1"`
+	PBoolTwo *bool      `lambda:"query.pbool2"`
+	Time     *time.Time `lambda:"query.time"`
+	Language string     `lambda:"header.Accept-Language"`
+	Encoding []string   `lambda:"header.Accept-Encoding"`
 }
 
 type mockGetRequest struct {


### PR DESCRIPTION
We need to pass a string to a time pointer on the lambda input but currently only bool pointers are supported

This PR adds support for `*time.Time` and adds test to validate