### PR TITLE
Add support for various pointer types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -176,9 +176,11 @@ func unmarshalField(
 	case reflect.Bool:
 		valueField.SetBool(boolRegex.MatchString(strings.ToLower(params[param])))
 	case reflect.Ptr:
-		switch typeField.Elem().Kind() {
-		case reflect.Struct:
-			if val, ok := params[param]; ok {
+		if val, ok := params[param]; ok {
+			switch typeField.Elem().Kind() {
+			case reflect.Int, reflect.Int32, reflect.Int64, reflect.String, reflect.Float32, reflect.Float64:
+				valueField.Set(reflect.ValueOf(&val).Convert(typeField))
+			case reflect.Struct:
 				if typeField.Elem() == reflect.TypeOf(time.Now()) {
 					parsedTime, err := time.Parse(time.RFC3339, val)
 					if err != nil {
@@ -186,9 +188,7 @@ func unmarshalField(
 					}
 					valueField.Set(reflect.ValueOf(&parsedTime))
 				}
-			}
-		case reflect.Bool:
-			if val, ok := params[param]; ok {
+			case reflect.Bool:
 				b := boolRegex.MatchString(strings.ToLower(val))
 				valueField.Set(reflect.ValueOf(&b))
 			}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/jgroeneveld/trial/assert"
 )
 
+type stringAliasExample string
+
+const aliasExample stringAliasExample = "world"
+
 func Test_UnmarshalRequest(t *testing.T) {
 	t.Run("valid path&query input", func(t *testing.T) {
 		var input mockListRequest
@@ -25,6 +29,8 @@ func Test_UnmarshalRequest(t *testing.T) {
 					"bool":      "true",
 					"pbool1":    "0",
 					"time":      "2021-11-01T11:11:11.000Z",
+					"alias":     "hello",
+					"alias_ptr": "world",
 				},
 				MultiValueQueryStringParameters: map[string][]string{
 					"terms":   []string{"one", "two"},
@@ -49,8 +55,11 @@ func Test_UnmarshalRequest(t *testing.T) {
 		assert.True(t, input.Bool, "Bool must be true")
 		assert.NotNil(t, input.PBoolOne, "PBoolOne must not be nil")
 		assert.False(t, *input.PBoolOne, "PBoolOne must be *false")
-		assert.NotNil(t, *input.Time, "Time must not be nil")
+		assert.NotNil(t, input.Time, "Time must not be nil")
 		assert.Equal(t, input.Time.Format(time.RFC3339), "2021-11-01T11:11:11Z")
+		assert.Equal(t, input.Alias, stringAliasExample("hello"))
+		assert.NotNil(t, input.AliasPtr)
+		assert.Equal(t, *input.AliasPtr, aliasExample)
 		assert.Equal(t, (*bool)(nil), input.PBoolTwo, "PBoolTwo must be nil")
 		assert.DeepEqual(t, []string{"one", "two"}, input.Terms, "Terms must be parsed from multiple query params")
 		assert.DeepEqual(t, []float64{1.2, 3.5, 666.666}, input.Numbers, "Numbers must be parsed from multiple query params")

--- a/structs_test.go
+++ b/structs_test.go
@@ -10,18 +10,20 @@ const (
 )
 
 type mockListRequest struct {
-	ID       string     `lambda:"path.id"`
-	Page     int64      `lambda:"query.page"`
-	PageSize int64      `lambda:"query.page_size"`
-	Terms    []string   `lambda:"query.terms"`
-	Numbers  []float64  `lambda:"query.numbers"`
-	Const    mockConst  `lambda:"query.const"`
-	Bool     bool       `lambda:"query.bool"`
-	PBoolOne *bool      `lambda:"query.pbool1"`
-	PBoolTwo *bool      `lambda:"query.pbool2"`
-	Time     *time.Time `lambda:"query.time"`
-	Language string     `lambda:"header.Accept-Language"`
-	Encoding []string   `lambda:"header.Accept-Encoding"`
+	ID       string              `lambda:"path.id"`
+	Page     int64               `lambda:"query.page"`
+	PageSize int64               `lambda:"query.page_size"`
+	Terms    []string            `lambda:"query.terms"`
+	Numbers  []float64           `lambda:"query.numbers"`
+	Const    mockConst           `lambda:"query.const"`
+	Bool     bool                `lambda:"query.bool"`
+	PBoolOne *bool               `lambda:"query.pbool1"`
+	PBoolTwo *bool               `lambda:"query.pbool2"`
+	Time     *time.Time          `lambda:"query.time"`
+	Alias    stringAliasExample  `lambda:"query.alias"`
+	AliasPtr *stringAliasExample `lambda:"query.alias_ptr"`
+	Language string              `lambda:"header.Accept-Language"`
+	Encoding []string            `lambda:"header.Accept-Encoding"`
 }
 
 type mockGetRequest struct {


### PR DESCRIPTION
Adds support for the following pointer types within input parameters:

- `*int`
- `*int32`
- `*int64`
- `*float32`
- `*float64`
- `*string`

This also includes aliased types for all of the above.

Currently these types are not decoded and left as `<nil>`, but are frequently required e.g. as optional parameters.