### PR TITLE
fix: unmarshal-number-pointers

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -40,24 +40,23 @@ var boolRegex = regexp.MustCompile(`^1|true|on|enabled$`)
 //
 // Example struct (no body):
 //
-//     type ListPostsInput struct {
-//         ID          uint64   `lambda:"path.id"`
-//         Page        uint64   `lambda:"query.page"`
-//         PageSize    uint64   `lambda:"query.page_size"`
-//         Search      string   `lambda:"query.search"`
-//         ShowDrafts  bool     `lambda:"query.show_hidden"`
-//         Languages   []string `lambda:"header.Accept-Language"`
-//     }
+//	type ListPostsInput struct {
+//	    ID          uint64   `lambda:"path.id"`
+//	    Page        uint64   `lambda:"query.page"`
+//	    PageSize    uint64   `lambda:"query.page_size"`
+//	    Search      string   `lambda:"query.search"`
+//	    ShowDrafts  bool     `lambda:"query.show_hidden"`
+//	    Languages   []string `lambda:"header.Accept-Language"`
+//	}
 //
 // Example struct (JSON body):
 //
-//     type UpdatePostInput struct {
-//         ID          uint64   `lambda:"path.id"`
-//         Author      string   `lambda:"header.Author"`
-//         Title       string   `json:"title"`
-//         Content     string   `json:"content"`
-//     }
-//
+//	type UpdatePostInput struct {
+//	    ID          uint64   `lambda:"path.id"`
+//	    Author      string   `lambda:"header.Author"`
+//	    Title       string   `json:"title"`
+//	    Content     string   `json:"content"`
+//	}
 func UnmarshalRequest(
 	req events.APIGatewayProxyRequest,
 	body bool,
@@ -189,7 +188,88 @@ func unmarshalField(
 	case reflect.Ptr:
 		if val, ok := params[param]; ok {
 			switch typeField.Elem().Kind() {
-			case reflect.Int, reflect.Int32, reflect.Int64, reflect.String, reflect.Float32, reflect.Float64:
+			case reflect.Int:
+				value, err := parseInt64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := int(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Int8:
+				value, err := parseInt64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := int8(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Int16:
+				value, err := parseInt64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := int16(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Int32:
+				value, err := parseInt64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := int32(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Int64:
+				value, err := parseInt64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				valueField.Set(reflect.ValueOf(&value))
+			case reflect.Uint:
+				value, err := parseUint64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := uint(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Uint8:
+				value, err := parseUint64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := uint8(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Uint16:
+				value, err := parseUint64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := uint16(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Uint32:
+				value, err := parseUint64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := uint32(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Uint64:
+				value, err := parseUint64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				valueField.Set(reflect.ValueOf(&value))
+			case reflect.Float32:
+				value, err := parseFloat64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				convertedValue := float32(value)
+				valueField.Set(reflect.ValueOf(&convertedValue))
+			case reflect.Float64:
+				value, err := parseFloat64Param(param, val, ok)
+				if err != nil {
+					return err
+				}
+				valueField.Set(reflect.ValueOf(&value))
+			case reflect.String:
 				valueField.Set(reflect.ValueOf(&val).Convert(typeField))
 			case reflect.Struct:
 				if typeField.Elem() == reflect.TypeOf(time.Now()) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -12,7 +12,9 @@ import (
 
 type stringAliasExample string
 
-const aliasExample stringAliasExample = "world"
+const (
+	aliasExample stringAliasExample = "world"
+)
 
 func Test_UnmarshalRequest(t *testing.T) {
 	t.Run("valid path&query input", func(t *testing.T) {
@@ -28,20 +30,21 @@ func Test_UnmarshalRequest(t *testing.T) {
 					"const":      "two",
 					"bool":       "true",
 					"pbool1":     "0",
+					"pint1":      "-1",
 					"time":       "2021-11-01T11:11:11.000Z",
 					"alias":      "hello",
 					"alias_ptr":  "world",
 					"commaSplit": "one,two,three",
 				},
 				MultiValueQueryStringParameters: map[string][]string{
-					"terms":   []string{"one", "two"},
-					"numbers": []string{"1.2", "3.5", "666.666"},
+					"terms":   {"one", "two"},
+					"numbers": {"1.2", "3.5", "666.666"},
 				},
 				Headers: map[string]string{
 					"Accept-Language": "en-us",
 				},
 				MultiValueHeaders: map[string][]string{
-					"Accept-Encoding": []string{"gzip", "deflate"},
+					"Accept-Encoding": {"gzip", "deflate"},
 				},
 			},
 			false,
@@ -56,6 +59,8 @@ func Test_UnmarshalRequest(t *testing.T) {
 		assert.True(t, input.Bool, "Bool must be true")
 		assert.NotNil(t, input.PBoolOne, "PBoolOne must not be nil")
 		assert.False(t, *input.PBoolOne, "PBoolOne must be *false")
+		assert.NotNil(t, input.PIntOne, "PIntOne must not be nil")
+		assert.Equal(t, *input.PIntOne, -1, "PIntOne must be .1")
 		assert.NotNil(t, input.Time, "Time must not be nil")
 		assert.Equal(t, input.Time.Format(time.RFC3339), "2021-11-01T11:11:11Z")
 		assert.Equal(t, input.Alias, stringAliasExample("hello"))
@@ -63,6 +68,7 @@ func Test_UnmarshalRequest(t *testing.T) {
 		assert.Equal(t, *input.AliasPtr, aliasExample)
 		assert.DeepEqual(t, []Number{numberOne, numberTwo, numberThree}, input.CommaSplit, "CommaSplit must have 2 items")
 		assert.Equal(t, (*bool)(nil), input.PBoolTwo, "PBoolTwo must be nil")
+		assert.Equal(t, (*int)(nil), input.PIntTwo, "PIntTwo must be nil")
 		assert.DeepEqual(t, []string{"one", "two"}, input.Terms, "Terms must be parsed from multiple query params")
 		assert.DeepEqual(t, []float64{1.2, 3.5, 666.666}, input.Numbers, "Numbers must be parsed from multiple query params")
 		assert.DeepEqual(t, []string{"gzip", "deflate"}, input.Encoding, "Encoding must be parsed from multiple header params")

--- a/structs_test.go
+++ b/structs_test.go
@@ -27,6 +27,8 @@ type mockListRequest struct {
 	Bool       bool                `lambda:"query.bool"`
 	PBoolOne   *bool               `lambda:"query.pbool1"`
 	PBoolTwo   *bool               `lambda:"query.pbool2"`
+	PIntOne    *int                `lambda:"query.pint1"`
+	PIntTwo    *int                `lambda:"query.pint2"`
 	Time       *time.Time          `lambda:"query.time"`
 	Alias      stringAliasExample  `lambda:"query.alias"`
 	AliasPtr   *stringAliasExample `lambda:"query.alias_ptr"`


### PR DESCRIPTION
When unmarshalling pointers to number types, an explicit conversion is needed, as the reflection conversion only works for non-pointer values. This PR adds explicit conversions for all number types.

This will fix #16.